### PR TITLE
chore/travis: increase cache usage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ branches:
   only:
     - master
 cache:
+  cargo: true
   directories:
     - $HOME/libsodium
     - $HOME/elfutils


### PR DESCRIPTION
This adds caching of cargo folders on Travis.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/maidsafe/secure_serialisation/16)
<!-- Reviewable:end -->
